### PR TITLE
ヘルスチェックの追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     puma (5.6.5)
@@ -154,6 +156,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/api/healthcheck_controller.rb
+++ b/app/controllers/api/healthcheck_controller.rb
@@ -1,0 +1,5 @@
+class Api::HealthcheckController < ApplicationController
+  def index
+    render json: { message: 'healthcheck success!!'}, status: 200
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace 'api' do
+    get '/healthcheck', to: 'healthcheck#index'
+  end
 end


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/NODASHUSEINANODA/ohana_api/issues/3

## やったこと

* APIの生存確認ができるように、ヘルスチェックを追加
* ルーティングの追加

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* `localhost:3001/api/healthcheck`にアクセスすると、`healthcheck success!!` とメッセージが表示される(ステータスコードは200)

## その他

* apiを作る上での慣例として、ルーティングは`api/`にするのが一般的のようなので、そのようにルーティングを設定しましたmm
* 何故かGemfile.lockが変更されており、軽く調べてみたところM1が原因のようでした。挙動には影響はなさそうです(あれば共有お願いします！！)
