### PR TITLE
Issue/#28 社員一覧の取得をログインしている会社ごとに制限

### DIFF
--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -1,4 +1,4 @@
-class Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+class Api::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
     private
 
     def sign_up_params

--- a/app/controllers/api/auth/sessions_controller.rb
+++ b/app/controllers/api/auth/sessions_controller.rb
@@ -1,0 +1,7 @@
+class Api::Auth::SessionsController < ApplicationController
+    def index
+        render json: {is_login: false, message: "ユーザーが存在しません"}, status: 401 unless current_api_company
+
+        render json: {is_login: true, data: current_api_company }
+    end
+end

--- a/app/controllers/api/employees_controller.rb
+++ b/app/controllers/api/employees_controller.rb
@@ -1,8 +1,8 @@
 class Api::EmployeesController < ApplicationController
+  before_action :authenticate_api_company!
+
   def index
-    # TODO: ログインユーザーの情報から会社に絞って社員を取得する(関係ない会社の社員まで取得するとSQL的に無駄な処理が多い)
-    @employees = Employee.all
-    search_condition
+    @employees = search_condition
 
     render json: @employees
   end
@@ -42,7 +42,7 @@ class Api::EmployeesController < ApplicationController
   private
 
   def search_condition
-    @employees = @employees
+    Employee
       .where(name_condition)
       .where(sex_condition)
       .where(birthday_condition)
@@ -98,11 +98,8 @@ class Api::EmployeesController < ApplicationController
     Employee.arel_table[:message].matches("%#{params[:message]}%")
   end
 
-  # TODO: ログインユーザーの会社IDを取得する(@userにはログインユーザーの情報を入れて、どのcontrollerでも使えるようにする)
   def company_condition
-    return nil unless @user
-
-    { company_id: @user.id }
+    { company_id: current_api_company.id }
   end
 
   def employee_params

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -1,6 +1,0 @@
-class Auth::SessionsController < ApplicationController
-    def index
-        render json: {is_login: true, data: current_user } if current_user
-        render json: {is_login: false, message: "ユーザーが存在しません"}, status: 401
-    end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,17 +4,26 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
 
-  # ログイン機能のルーティング
-  mount_devise_token_auth_for 'Company', at: 'auth', controllers: {
-    registrations: 'auth/registrations'
-  }
-  # ログインユーザー取得のルーティング
-  namespace :auth do
-    resources :sessions, only: %i[index]
-  end
+  # # ログイン機能のルーティング
+  # mount_devise_token_auth_for 'Company', at: 'auth', controllers: {
+  #   registrations: 'auth/registrations'
+  # }
+  # # ログインユーザー取得のルーティング
+  # namespace :auth do
+  #   resources :sessions, only: %i[index]
+  # end
 
   namespace 'api' do
     resources :employees
     get '/healthcheck', to: 'healthcheck#index'
+
+    # ログイン機能のルーティング
+    mount_devise_token_auth_for 'Company', at: 'auth', controllers: {
+      registrations: 'api/auth/registrations'
+    }
+    # ログインユーザー取得のルーティング
+    namespace 'auth' do
+      resources :sessions, only: %i[index]
+    end
   end
 end


### PR DESCRIPTION
## チケットへのリンク

* close #28 

## やったこと

* apiのルーティングは/api配下に置くことが一般的だから、auth関連もapi配下に移動
* 社員一覧の取得をログインしている会社ごとに制限

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 他の会社の社員情報のCRUD操作ができなくなった
  * ログインしていないと処理ができない かつ ログイン後はその会社のidで検索を絞るので、他の会社の社員情報を操作できない

## できなくなること（ユーザ目線）

* Employeeコントローラーでの全ての処理で、headerに`client`,`access-token`,`uid`が必要になった

## 動作確認

* frontからログインした会社の社員しか閲覧、編集できないことを確認(下のfrontのプルリクで、今回の変更に合わせてfonrtも変更してます！)
  * https://github.com/NODASHUSEINANODA/ohana/pull/40

## その他

* auth系のコントローラー、api配下に移動させました！
* あとissueに書いている`どのcontrollerからもログインユーザー(会社)の値を取得できるようにする`ってやつ、devise_token_auth`のgemの中で機能あって、もうみーやが実装してくれてた！ありがとう！！
