### PR TITLE
Issue/#29 メール送信機能の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,177 @@
+# default
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
+  Enabled: true
+Gemspec/DevelopmentDependencies: # new in 1.44
+  Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: true
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: true
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: true
+Lint/SymbolConversion: # new in 1.9
+  Enabled: true
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: true
+Lint/TripleQuotes: # new in 1.9
+  Enabled: true
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: true
+Lint/UselessRescue: # new in 1.43
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+Metrics/CollectionLiteralLength: # new in 1.47
+  Enabled: true
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Security/IoMethods: # new in 1.22
+  Enabled: true
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
+Style/ArrayIntersect: # new in 1.40
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
+  Enabled: true
+Style/ComparableClamp: # new in 1.44
+  Enabled: true
+Style/ConcatArrayLiterals: # new in 1.41
+  Enabled: true
+Style/DataInheritance: # new in 1.49
+  Enabled: true
+Style/DirEmpty: # new in 1.48
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/FileEmpty: # new in 1.48
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapToHash: # new in 1.24
+  Enabled: true
+Style/MapToSet: # new in 1.42
+  Enabled: true
+Style/MinMaxComparison: # new in 1.42
+  Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
+  Enabled: true
+Style/RedundantConstantBase: # new in 1.40
+  Enabled: true
+Style/RedundantDoubleSplatHashBraces: # new in 1.41
+  Enabled: true
+Style/RedundantEach: # new in 1.38
+  Enabled: true
+Style/RedundantHeredocDelimiterQuotes: # new in 1.45
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+Style/RedundantLineContinuation: # new in 1.49
+  Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
+Style/SwapValues: # new in 1.1
+  Enabled: true
+
+# Missing top-level documentation comment for の警告が出ないようにする
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'letter_opener_web'
 end
 
 gem "faker", "3.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
@@ -134,6 +136,15 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -181,6 +192,7 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -319,6 +331,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jquery-rails
+  letter_opener_web
   mysql2 (~> 0.5)
   pry-byebug
   pry-rails

--- a/app/mailers/company_mailer.rb
+++ b/app/mailers/company_mailer.rb
@@ -1,0 +1,2 @@
+class CompanyMailer < ApplicationMailer
+end

--- a/app/mailers/company_mailer.rb
+++ b/app/mailers/company_mailer.rb
@@ -1,2 +1,15 @@
 class CompanyMailer < ApplicationMailer
+  def order_to_flower_shop
+    @company_name = params[:company_name]
+    @company_email = params[:company_email]
+    @flower_shop_name = params[:flower_shop_name]
+    @flower_shop_email = params[:flower_shop_email]
+    @birthday_members = params[:members]
+
+    mail(
+      to: @flower_shop_email,
+      from: @company_email,
+      subject: "注文依頼",
+    )
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,6 @@
 class Company < ApplicationRecord
   has_many :employees, dependent: :destroy
-  has_one :flower_shop
+  belongs_to :flower_shop
 
   validates :name, presence: true, length: { maximum: 20, allow_blank: true }
   validates :address, presence: true, length: { maximum: 20, allow_blank: true }

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,8 +9,8 @@ class Company < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
 
-  def current_month_order_to_flower_shop
-    members = self.birthday_in_current_month_members
+  def next_month_order_to_flower_shop
+    members = self.birthday_in_next_month_members
 
     CompanyMailer.with(
       company_name: self.name,
@@ -23,9 +23,9 @@ class Company < ApplicationRecord
 
   private
 
-  def birthday_in_current_month_members
-    current_month = Time.zone.now.strftime("%m")
-    birthday_in_current_month_condition = Employee.arel_table[:birthday].extract('month').eq(current_month)
-    employees.where(birthday_in_current_month_condition)
+  def birthday_in_next_month_members
+    next_month = Time.zone.now.next_month.strftime("%m")
+    birthday_in_next_month_condition = Employee.arel_table[:birthday].extract('month').eq(next_month)
+    employees.where(birthday_in_next_month_condition)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,12 +1,10 @@
 class Company < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :employees, dependent: :destroy
   has_one :flower_shop
 
   validates :name, presence: true, length: { maximum: 20, allow_blank: true }
   validates :address, presence: true, length: { maximum: 20, allow_blank: true }
-  
+
   # この:validatableはpasswordとemailしか検証してくれない
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
@@ -14,7 +12,13 @@ class Company < ApplicationRecord
   def current_month_order_to_flower_shop
     members = self.birthday_in_current_month_members
 
-    CompanyMailer.with(members: members).order_to_flower_shop.deliver_now if members.present?
+    CompanyMailer.with(
+      company_name: self.name,
+      company_email: self.email,
+      flower_shop_name: self.flower_shop.name,
+      flower_shop_email: self.flower_shop.email,
+      members: members,
+    ).order_to_flower_shop.deliver_now if members.present?
   end
 
   private

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,7 @@
 class Company < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :employees, dependent: :destroy
   has_one :flower_shop
 
   validates :name, presence: true, length: { maximum: 20, allow_blank: true }
@@ -10,4 +11,17 @@ class Company < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
 
+  def current_month_order_to_flower_shop
+    members = self.birthday_in_current_month_members
+
+    CompanyMailer.with(members: members).order_to_flower_shop.deliver_now if members.present?
+  end
+
+  private
+
+  def birthday_in_current_month_members
+    current_month = Time.zone.now.strftime("%m")
+    birthday_in_current_month_condition = Employee.arel_table[:birthday].extract('month').eq(current_month)
+    employees.where(birthday_in_current_month_condition)
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,7 @@
 class Company < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_one :flower_shop
 
   validates :name, presence: true, length: { maximum: 20, allow_blank: true }
   validates :address, presence: true, length: { maximum: 20, allow_blank: true }

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -12,6 +12,11 @@ class Employee < ApplicationRecord
         birthday.strftime('%Y年%m月%d日')
     end
 
+    # MM月DD日の形式で誕生日を返す
+    def birthday_format_mm_dd
+        birthday.strftime('%m月%d日')
+    end
+
     def age
         now = Date.today.year
         now - birthday.year

--- a/app/models/flower_shop.rb
+++ b/app/models/flower_shop.rb
@@ -1,6 +1,6 @@
 class FlowerShop < ApplicationRecord
     has_many :histories
-    belongs_to :company
+    has_many :company
 
     validates :name, :email, presence: true
 end

--- a/app/models/flower_shop.rb
+++ b/app/models/flower_shop.rb
@@ -2,5 +2,5 @@ class FlowerShop < ApplicationRecord
     has_many :histories
     belongs_to :company
 
-    validates :name, :mail, presence: true
+    validates :name, :email, presence: true
 end

--- a/app/models/flower_shop.rb
+++ b/app/models/flower_shop.rb
@@ -1,5 +1,6 @@
 class FlowerShop < ApplicationRecord
     has_many :histories
+    belongs_to :company
 
     validates :name, :mail, presence: true
 end

--- a/app/views/company_mailer/order_to_flower_shop.html.erb
+++ b/app/views/company_mailer/order_to_flower_shop.html.erb
@@ -5,13 +5,12 @@
   <body>
     <h3><%= @flower_shop_name %> 様</h3>
 
-    <%# TODO: メールを送る日付はいつ？？月末に来月誕生日の人向けに送るの？月頭？どっち？？  %>
     <p>以下で指定された住所と日付にお花を送ってください。</p>
 
     <ul>
       <% @birthday_members.each do |member| %>
-        <%# TODO: メニューを動的に選択できるようにした方が良さそう??(仕様面、要確認) %>
-        <li><%= member.name %> <%= member.address %> バラセット 10000円</li>
+        <%# TODO: メニューのところは社長専用ページの操作結果から動的に変更できるようにする %>
+        <li><%= member.name %> <%= member.birthday_format_mm_dd %> <%= member.address %> バラセット 10000円</li>
       <% end %>
     </ul>
 

--- a/app/views/company_mailer/order_to_flower_shop.html.erb
+++ b/app/views/company_mailer/order_to_flower_shop.html.erb
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h3><%= @flower_shop_name %> 様</h3>
+
+    <%# TODO: メールを送る日付はいつ？？月末に来月誕生日の人向けに送るの？月頭？どっち？？  %>
+    <p>以下で指定された住所と日付にお花を送ってください。</p>
+
+    <ul>
+      <% @birthday_members.each do |member| %>
+        <%# TODO: メニューを動的に選択できるようにした方が良さそう??(仕様面、要確認) %>
+        <li><%= member.name %> <%= member.address %> バラセット 10000円</li>
+      <% end %>
+    </ul>
+
+    <div class="my-3">
+      <p>このメールはシステムから自動送信されています。</p>
+      <p>ご不明な点がございましたら、お手数おかけしますがご返信お願いします。</p>
+    </div>
+
+    <h3><%= @company_name %></h3>
+  </body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,7 +73,10 @@ Rails.application.configure do
   config.action_mailer.default_options = { from: ENV['EMAIL_ADDRESS'] }
   # hostにはデフォルトでlocalhost3000になっているので、Railsのポート番号である3000に変更する。
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  config.action_mailer.delivery_method = :smtp
+
+  # NOTE : 実際に送信して検証したい際は :letter_opener_web をコメントアウトして、:smtp のコメントアウトをはずしてください
+  # config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.smtp_settings = {
     address: 'smtp.gmail.com',
     port: 587,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  # NOTE : 開発環境で`/letter_opener`で送信したメールを確認できる(実際に送信して検証したい際はコメントアウトしてください)
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   devise_for :companies, controllers: { registrations: 'companies/registrations' }
 
   namespace 'api' do

--- a/db/migrate/20230607160525_add_associate_to_company.rb
+++ b/db/migrate/20230607160525_add_associate_to_company.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAssociateToCompany < ActiveRecord::Migration[7.0]
+  def change
+    change_table :flower_shops do |t|
+      t.references :company, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20230607160525_add_associate_to_company.rb
+++ b/db/migrate/20230607160525_add_associate_to_company.rb
@@ -2,8 +2,8 @@
 
 class AddAssociateToCompany < ActiveRecord::Migration[7.0]
   def change
-    change_table :flower_shops do |t|
-      t.references :company, foreign_key: true
+    change_table :companies do |t|
+      t.references :flower_shop, foreign_key: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,7 +25,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_160525) do
     t.string "address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "flower_shop_id"
     t.index ["email"], name: "index_companies_on_email", unique: true
+    t.index ["flower_shop_id"], name: "index_companies_on_flower_shop_id"
     t.index ["reset_password_token"], name: "index_companies_on_reset_password_token", unique: true
   end
 
@@ -48,8 +50,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_160525) do
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "company_id"
-    t.index ["company_id"], name: "index_flower_shops_on_company_id"
   end
 
   create_table "histories", charset: "utf8mb4", force: :cascade do |t|
@@ -82,8 +82,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_160525) do
     t.index ["manager_id"], name: "index_temporaries_on_manager_id"
   end
 
+  add_foreign_key "companies", "flower_shops"
   add_foreign_key "employees", "companies"
-  add_foreign_key "flower_shops", "companies"
   add_foreign_key "histories", "employees"
   add_foreign_key "histories", "flower_shops"
   add_foreign_key "histories", "managers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_06_125952) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_07_160525) do
   create_table "companies", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -48,6 +48,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_06_125952) do
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "company_id"
+    t.index ["company_id"], name: "index_flower_shops_on_company_id"
   end
 
   create_table "histories", charset: "utf8mb4", force: :cascade do |t|
@@ -81,6 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_06_125952) do
   end
 
   add_foreign_key "employees", "companies"
+  add_foreign_key "flower_shops", "companies"
   add_foreign_key "histories", "employees"
   add_foreign_key "histories", "flower_shops"
   add_foreign_key "histories", "managers"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,8 @@
 end
 
 50.times do |n|
-  s1 = Date.parse('2000/06/1')
-  s2 = Date.parse('2000/06/30')
+  s1 = Date.parse('2000/07/1')
+  s2 = Date.parse('2000/07/30')
   s = Random.rand(s1..s2)
   Employee.create!(
     name: Gimei.unique.name.kanji,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,23 @@
 3.times do |n|
+  FlowerShop.create!(
+    name: Gimei.name.last.kanji.concat('花屋'),
+    email: "flower#{n + 1}@example.com",
+    created_at: Time.current,
+    updated_at: Time.current
+  )
+end
+
+# flower_shop_idはflower_shopのデータが作成されていることが前提、順番変えるとうまくいかない
+3.times do |n|
+  flower_shop_id_first = FlowerShop.first.id
+  flower_shop_id_last = FlowerShop.last.id
   Company.create!(
     email: "test#{n + 1}@example.com",
     password: 'password',
     name: "test#{n}株式会社",
     address: Gimei.unique.address,
-    confirmed_at: Time.current
+    confirmed_at: Time.current,
+    flower_shop_id: Random.rand(flower_shop_id_first..flower_shop_id_last)
   )
 end
 
@@ -14,24 +27,12 @@ end
   s = Random.rand(s1..s2)
   Employee.create!(
     name: Gimei.unique.name.kanji,
-    sex: Random.rand(1..2) == 2 ? '男' : '女',
+    sex: Random.rand(1..2) == 2 ? '男性' : '女性',
     birthday: s,
     address: Gimei.unique.address,
     joined_at: s,
     phone_number: '09011112222',
     message: Random.rand(1..2) == 2 ? '情熱的' : '落ち着いている',
     company_id: Random.rand(1..3)
-  )
-end
-
-# company_idはcompanyのデータが作成されていることが前提、順番変えるとうまくいかない
-
-3.times do |n|
-  FlowerShop.create!(
-    name: Gimei.name.last.kanji.concat('花屋'),
-    email: "flower#{n + 1}@example.com",
-    created_at: Time.current,
-    updated_at: Time.current,
-    company_id: Company.find_by(id: n + 1).id
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,54 +1,25 @@
 3.times do |n|
-    Company.create!(
-        name: Gimei.unique.last.to_s.concat("株式会社"),
-        address: Gimei.unique.address,
-        email: Faker::Internet.unique.email,
-    )
-end
-
-3.times do |n|
-    FlowerShop.create!(
-        name: Gimei.unique.last.to_s.concat("花屋"),
-        email: Faker::Internet.unique.email,
-    )
-end
-
-def generateSex()
-    if Random.rand(1..11).even?
-        return "男性"
-    else
-        return "女性"
-    end
-end
-
-def generateText()
-    if Random.rand(0..2) == 1
-        return "赤が好き"
-    else
-        return "白が好き"
-    end
+  Company.create!(
+    email: "test#{n + 1}@example.com",
+    password: 'password',
+    name: "test#{n}株式会社",
+    address: Gimei.unique.address,
+    confirmed_at: Time.current
+  )
 end
 
 50.times do |n|
-    s1 = Date.parse("1970/01/1")
-    s2 = Date.parse("2000/12/31")
-    s = Random.rand(s1 .. s2)
-    Employee.create!(
-        name: Gimei.unique.name.kanji,
-        sex: generateSex,
-        birthday: s,
-        address: Gimei.unique.address,
-        joined_at: s,
-        phone_number: "09011112222",
-        message: generateText,
-        company_id: Random.rand(1..3),
-    )
-end
-
-3.times do |n|
-    Manager.create!(
-        employee_id: Random.rand(1..50),
-        email: Faker::Internet.unique.email,
-        status: Random.rand(0..2) == 1 ? true : false,
-    )
+  s1 = Date.parse('2000/06/1')
+  s2 = Date.parse('2000/06/30')
+  s = Random.rand(s1..s2)
+  Employee.create!(
+    name: Gimei.unique.name.kanji,
+    sex: Random.rand(1..2) == 2 ? '男' : '女',
+    birthday: s,
+    address: Gimei.unique.address,
+    joined_at: s,
+    phone_number: '09011112222',
+    message: Random.rand(1..2) == 2 ? '情熱的' : '落ち着いている',
+    company_id: Random.rand(1..3)
+  )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,3 +23,15 @@ end
     company_id: Random.rand(1..3)
   )
 end
+
+# company_idはcompanyのデータが作成されていることが前提、順番変えるとうまくいかない
+
+3.times do |n|
+  FlowerShop.create!(
+    name: Gimei.name.last.kanji.concat('花屋'),
+    email: "flower#{n + 1}@example.com",
+    created_at: Time.current,
+    updated_at: Time.current,
+    company_id: Company.find_by(id: n + 1).id
+  )
+end

--- a/lib/tasks/send_mail/to_flower_shop.rb
+++ b/lib/tasks/send_mail/to_flower_shop.rb
@@ -2,7 +2,7 @@ class Tasks::SendMail::ToFlowerShop < Tasks::AbstBatch
   def self.exec
     execute('花屋さんへメールを送信します') do
       Company.all.each do |company|
-        company.current_month_order_to_flower_shop
+        company.next_month_order_to_flower_shop
       end
     end
   end

--- a/lib/tasks/send_mail/to_flower_shop.rb
+++ b/lib/tasks/send_mail/to_flower_shop.rb
@@ -1,8 +1,9 @@
 class Tasks::SendMail::ToFlowerShop < Tasks::AbstBatch
   def self.exec
     execute('花屋さんへメールを送信します') do
-      # TODO: ここにメールを送信する処理を書く
-      puts 'hogehoge'
+      Company.all.each do |company|
+        company.current_month_order_to_flower_shop
+      end
     end
   end
 end

--- a/spec/mailers/company_spec.rb
+++ b/spec/mailers/company_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe CompanyMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/company_preview.rb
+++ b/spec/mailers/previews/company_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/company
+class CompanyPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
## チケットへのリンク

* close #29 

## やったこと
* migrationで外部キーを追加して、会社と花屋を紐づけた
  * メールを送信する際に会社と花屋が紐づいていないと、花屋を選択する際に `FlowerShop.first` みたいな選択の仕方になってしまうので、会社に紐づけた
* 今月、誕生日の社員の情報を取得する処理を追加
* 取得した社員情報を載せたメール文を作成
* メール送信ができていることを確認するためのgemを追加 ( `letter_opener_web` ) 
* rubocopの設定ファイルを追加
  *  挙動には直接関係あるわけではないので、気にしないで下さい ><

## やらないこと

* メール文を整える
  * デザイン段階のメール文に少し手を加えた程度にしている
  * 改善の余地があると思うので、そちらは別のプルリクで対応する
* 花屋へのメールを送る際の仕様の確認(以下、疑問点だがこのプルリクでは `バッチ処理でメールを花屋に送信する` ことを目的としているため、必要があれば別のプルリクで対応)
  * メールを送信するタイミングっていつだっけ？？問題
    * メールを毎月1日に送信する場合、1日に誕生日の方がいた場合、間に合わない
    * お花の渡すタイミングをどこまで許容しているかによって変わると思う。(誕生月内に届けば良いのであればこのまま月初めにメールを送って良いと思う)
    * そうでなければ、前の月の後半くらいのタイミングで来月の誕生日の方の情報を花屋に送る必要があると思う。(ここら辺は、クライアントに要相談)
  * メール文に記載しているメニューってあれで良かったっけ??
    * どこかで話した記憶もあるけど、探せなかったmm
  * 花屋へのメニューは動的に選択できるようにした方が良さそう? (優先度的には低め)
    * 今のメニューじゃなくて、別のメニューにしたいってなった時に現状だと、直接コードを編集しないとできない = エンジニアしかできないので運用的にキツそう

## できるようになること（ユーザ目線）

* `rails runner Tasks::SendMail::ToFlowerShop.exec` で今月誕生日の社員情報を取得し、それぞれの会社の紐づく花屋へメールを送信 ( 特定の会社ではなく、全会社分の処理が走るようになる )

## できなくなること（ユーザ目線）

* なし

## 動作確認

* データ(社員の誕生日が今月になるようする)を用意してコマンドを実行、`http://localhost:3000/letter_opener` を確認してメールが送られていることを確認
* 以下、確認方法
  * gemを追加したので、`bundle install` 
  * migrationも追加したので、`rails db:migrate` 
  * 誕生日が今月になるような社員のデータを作成
  * `rails runner Tasks::SendMail::ToFlowerShop.exec` を実行
  * `http://localhost:3000/letter_opener` を確認

## その他

* やらないことに記載している仕様面について、確認してほしいです。時間が経って、仕様が曖昧になっているのでmm
* `letter_opener_web` は、開発環境下での全メールを置き換えるので、実際に送信して検証した場合は、設定ファイル(`config/environments/development.rb`)とルーティング(`config/routes.rb`)のコメントアウトをはずしてください
