### PR TITLE
Issue/#53 注文内容リストタグではなく、テーブルタグにして見やすくする

### DIFF
--- a/app/mailers/company_mailer.rb
+++ b/app/mailers/company_mailer.rb
@@ -11,7 +11,7 @@ class CompanyMailer < ApplicationMailer
     mail(
       to: @flower_shop_email,
       from: @company_email,
-      subject: '注文依頼'
+      subject: '【ONE-STEP-GIFT】来月の注文依頼'
     )
   end
 end

--- a/app/views/company_mailer/order_to_flower_shop.html.erb
+++ b/app/views/company_mailer/order_to_flower_shop.html.erb
@@ -1,17 +1,34 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   </head>
-  <body>
+  <body style="background-color: white;">
     <h3><%= @flower_shop_name %> 様</h3>
 
-    <p>以下で指定された住所と日付にお花を送ってください。</p>
+    <p>来月の注文内容は以下になります。よろしくお願いします。</p>
 
-    <ul>
-      <% @next_orders_info.each do |info| %>
-        <li><%= info[:employee_name] %> <%= info[:employee_birthday] %> <%= info[:delivery_address] %> <%= info[:menu_name_with_price] %></li>
-      <% end %>
-    </ul>
+    <table class="table table-striped table-hover">
+      <thead>
+        <tr>
+          <th>名前</th>
+          <th>到着日付</th>
+          <th>宛先</th>
+          <th>メニュー</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @next_orders_info.each do |info| %>
+          <tr>
+              <td class='align-middle small'><%= info[:employee_name] %></td>
+              <td class='align-middle small'><%= info[:employee_birthday] %></td>
+              <td class='align-middle small'><%= info[:delivery_address] %></td>
+              <td class='align-middle small'><%= info[:menu_name_with_price] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
 
     <div class="my-3">
       <p>このメールはシステムから自動送信されています。</p>


### PR DESCRIPTION
## チケットへのリンク

* close #53 

## やったこと

* 注文内容リストタグではなく、テーブルタグにして見やすくする
* スタイルを付与

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* letter_openner_webで見た目を確認

## スクショ
<img width="655" alt="スクリーンショット 2023-06-25 14 27 22" src="https://github.com/NODASHUSEINANODA/ohana_api/assets/69576936/93bb2501-0cf2-474e-92c0-6ce44653cc86">

## その他

* 軽微な修正なので、こちらでマージさせていただきますmm
