### PR TITLE
issue/#94 feat : 入社日の絞り込み検索を日付ではなく、年と月での検索をできるようにした

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -139,7 +139,16 @@ class EmployeesController < ApplicationController
   def joined_at_condition
     return nil if params[:joined_at].blank?
 
-    { joined_at: params[:joined_at] }
+    year = params[:joined_at][:year]
+    month = params[:joined_at][:month]
+
+    return Employee.arel_table[:joined_at].extract('month').eq(month.to_i) if year.nil?
+    return Employee.arel_table[:joined_at].extract('year').eq(year.to_i) if month.nil?
+
+    year_matches = Employee.arel_table[:joined_at].extract('year').eq(year.to_i)
+    month_matches = Employee.arel_table[:joined_at].extract('month').eq(month.to_i)
+
+    year_matches.and(month_matches)
   end
 
   def phone_number_condition

--- a/app/views/employees/_search_form.html.erb
+++ b/app/views/employees/_search_form.html.erb
@@ -3,29 +3,37 @@
 
   <%= form_with(url: employees_path , method: :get, remote: true, local: true) do |form| %>
     <div class="row mt-2 mb-4 py-3 container rounded shadow bg-white">
-      <div class="col-2">
+      <%# 上列 %>
+      <div class="col-4 mb-3">
         <%= form.label '名前' , class: "form-label" %>
           <%= form.text_field :name, value: "" , class: "form-control" , id: "name" %>
       </div>
-      <div class="col-1">
+      <div class="col-4 mb-3">
         <%= form.label '性別' , class: "form-label" %>
           <%= form.select :sex, [["--選択--", "invalid" ], ["男性", "男性" ], ["女性", "女性" ], ["無回答", "無回答" ]], {},
             class: "form-select" , aria: {label: "sex" }, id: "sex" %>
       </div>
-      <div class="col-2">
+      <div class="col-4 mb-3">
         <%= form.label 'お誕生日' , class: "form-label" %>
           <%= form.date_field :birthday, class: "form-control" , id: "birthday" %>
       </div>
-      <div class="col-3">
+      <%# 下列 %>
+      <div class="col-4 mb-3">
         <%= form.label '住所' , class: "form-label" %>
           <%= form.text_field :address, class: "form-control" , id: "address" %>
       </div>
-      <div class="col-2">
-        <%= form.label '入社日' , class: "form-label" %>
+      <div class="col-4 mb-3 row mx-0">
+        <div class="col-12 px-0">
+          <%= form.label '入社日' , class: "form-label" %>
+        </div>
+        <div class="col-7 p-0">
           <%= form.select 'joined_at[year]', options_for_select([["年", "invalid"]] + (1960..Time.now.year).map { |m| [m.to_s + "年", m] } ), {}, {class: "form-select"} %>
+        </div>
+        <div class="col-5 p-0">
           <%= form.select 'joined_at[month]', options_for_select([['月', "invalid"]] + (1..12).map { |m| [m.to_s + "月", m] } ), {}, {class: "form-select"} %>
+        </div>
       </div>
-      <div class="col-2">
+      <div class="col-4 mb-3">
         <%= form.label '電話番号' , class: "form-label" %>
           <%= form.text_field :phone_number, class: "form-control" , id: "phone_number" %>
       </div>

--- a/app/views/employees/_search_form.html.erb
+++ b/app/views/employees/_search_form.html.erb
@@ -22,7 +22,8 @@
       </div>
       <div class="col-2">
         <%= form.label '入社日' , class: "form-label" %>
-          <%= form.date_field :joined_at, class: "form-control" , id: "joined_at" %>
+          <%= form.select 'joined_at[year]', options_for_select([["年", "invalid"]] + (1960..Time.now.year).map { |m| [m.to_s + "年", m] } ), {}, {class: "form-select"} %>
+          <%= form.select 'joined_at[month]', options_for_select([['月', "invalid"]] + (1..12).map { |m| [m.to_s + "月", m] } ), {}, {class: "form-select"} %>
       </div>
       <div class="col-2">
         <%= form.label '電話番号' , class: "form-label" %>


### PR DESCRIPTION
## チケットへのリンク

* #94 

## やったこと

* 入社日の絞り込み検索を日付ではなく、年と月での検索をできるようにした
* 年だけの検索、月だけの検索も可能

## やらないこと

* 日付での検索

## できるようになること（ユーザ目線）

* 入社日での絞り込みを年と月でできるようにした

## できなくなること（ユーザ目線）

* 日付での検索

## 動作確認

* セレクトボックスで年と月を選んで検索してみてほしい！

## その他

* しゅーたのarel_tableの記事を見た！
* 正直もっと簡潔に書けそうな気がする
* あとは、UIかな年と月が縦に並んでるのが、気になったりするかな？？
