### PR TITLE
issue/#96 feat : 次回注文がない時は、次回の注文はありませんを表示する

### DIFF
--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -1,5 +1,9 @@
 <div class="container my-2">
-  <p class="h2 text-center">次回の注文確認</p>
+  <% if @next_order_details.empty? %>
+    <p class="h2 text-center text-danger">次回の注文はありません</p>
+  <% else %>
+    <p class="h2 text-center">次回の注文確認</p>
+  <% end %>
 
   <%= form_with(path: next_order_path, method: :put, local: true) do |form| %>
     <table class="table table-striped table-hover">

--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -1,66 +1,66 @@
 <div class="container my-2">
   <% if @next_order_details.empty? %>
-    <p class="h2 text-center text-danger">次回の注文はありません</p>
+    <p class="h2 text-center text-danger my-5">次回の注文はありません</p>
   <% else %>
     <p class="h2 text-center">次回の注文確認</p>
-  <% end %>
-
-  <%= form_with(path: next_order_path, method: :put, local: true) do |form| %>
-    <table class="table table-striped table-hover">
-      <thead class='bg-white'>
-        <tr>
-          <th>名前</th>
-          <th>性別</th>
-          <th>誕生日</th>
-          <th>年齢</th>
-          <th>住所</th>
-          <th>勤続年数</th>
-          <th>送り先</th>
-          <th>メニュー</th>
-          <th>今回は送らない</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @next_order_details.each_with_index do |details| %>
-          <%= fields_for 'details[]', details do |detail| %>
-            <tr>
-              <td class='align-middle small'><%= detail.object.employee.name %></td>
-              <td class='align-middle small'><%= detail.object.employee.sex %></td>
-              <td class='align-middle small'><%= detail.object.employee.birthday_format_mm_dd %></td>
-              <td class='align-middle small'><%= detail.object.employee.age %>歳</td>
-              <td class='align-middle small'><%= detail.object.employee.address %></td>
-              <td class='align-middle small'><%= detail.object.employee.working_years %>年</td>
-              <td class='align-middle small'>
-                <% if detail.object.employee.address %>
-                  <%= detail.select :deliver_to,
-                      options_for_select(@deliver_to, selected: detail.object.deliver_to),
+    <%= form_with(path: next_order_path, method: :put, local: true) do |form| %>
+      <table class="table table-striped table-hover">
+        <thead class='bg-white'>
+          <tr>
+            <th>名前</th>
+            <th>性別</th>
+            <th>誕生日</th>
+            <th>年齢</th>
+            <th>住所</th>
+            <th>勤続年数</th>
+            <th>送り先</th>
+            <th>メニュー</th>
+            <th>今回は送らない</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @next_order_details.each_with_index do |details| %>
+            <%= fields_for 'details[]', details do |detail| %>
+              <tr>
+                <td class='align-middle small'><%= detail.object.employee.name %></td>
+                <td class='align-middle small'><%= detail.object.employee.sex %></td>
+                <td class='align-middle small'><%= detail.object.employee.birthday_format_mm_dd %></td>
+                <td class='align-middle small'><%= detail.object.employee.age %>歳</td>
+                <td class='align-middle small'><%= detail.object.employee.address %></td>
+                <td class='align-middle small'><%= detail.object.employee.working_years %>年</td>
+                <td class='align-middle small'>
+                  <% if detail.object.employee.address %>
+                    <%= detail.select :deliver_to,
+                        options_for_select(@deliver_to, selected: detail.object.deliver_to),
+                        {},
+                        {class: "form-select w-100"}
+                    %>
+                  <% else %>
+                    <%= detail.select :deliver_to,
+                        options_for_select(@deliver_to, selected: @deliver_to['会社'], disabled: @deliver_to['自宅']),
+                        {},
+                        {class: "form-select w-100"}
+                    %>
+                  <% end %>
+                </td>
+                <td class='align-middle small'>
+                  <%= detail.select :menu_id,
+                      options_from_collection_for_select(@menus, "id", "name_with_price", detail.object.menu_id),
                       {},
                       {class: "form-select w-100"}
                   %>
-                <% else %>
-                  <%= detail.select :deliver_to,
-                      options_for_select(@deliver_to, selected: @deliver_to['会社'], disabled: @deliver_to['自宅']),
-                      {},
-                      {class: "form-select w-100"}
-                  %>
-                <% end %>
-              </td>
-              <td class='align-middle small'>
-                <%= detail.select :menu_id,
-                    options_from_collection_for_select(@menus, "id", "name_with_price", detail.object.menu_id),
-                    {},
-                    {class: "form-select w-100"}
-                %>
-              </td>
-              <td class='align-middle small'>
-                <%= detail.check_box :discard ,{checked: detail.object.discarded?, class: "form-check w-75 text-center"}, true, false %>
-              </td>
-            </tr>
+                </td>
+                <td class='align-middle small'>
+                  <%= detail.check_box :discard ,{checked: detail.object.discarded?, class: "form-check w-75 text-center"}, true, false %>
+                </td>
+              </tr>
+            <% end %>
           <% end %>
-        <% end %>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
 
-    <%= form.submit "更新", class: "btn btn-primary w-100 my-3 py-2" %>
+      <%= form.submit "更新", class: "btn btn-primary w-100 my-3 py-2" %>
+    <% end %>
   <% end %>
+
 </div>


### PR DESCRIPTION
## チケットへのリンク

* #96 
## やったこと

* @next_ordersが空の場合に、「次回の注文確認」のところに「次回の注文はありません」を表示する

## やらないこと

* なし

## 動作確認
* もう7月入ったので、てきとーにデフォルトのseedでは次回データ作られないからそれで確認して、てきとーに8月の社員登録して、次回データ作成して、切り替わっているか確認くらい

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
