### PR TITLE
issue/#107 feat : 社員作成時に翌月誕生日なら注文データに追加する

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -24,11 +24,11 @@ class EmployeesController < ApplicationController
       rescue ActiveRecord::RecordInvalid => e
         flash[:danger] = e.record.errors.full_messages.join(', ')
       end
-    elsif @employee.save
-      # 社員のみの場合
+    elsif @employee.birthday_is_next_month?
+      @employee.save_with_order_detail(current_company)
       flash[:success] = '社員を登録しました'
-
-      update_order_detail if @employee.birthday_is_next_month?
+    elsif @employee.save!
+      flash[:success] = '社員を登録しました'
     else
       flash[:danger] = '社員の登録に失敗しました'
     end
@@ -57,16 +57,6 @@ class EmployeesController < ApplicationController
   end
 
   private
-
-  def update_order_detail
-    OrderDetail.create(
-      order_id: current_company.order_ids.last,
-      employee_id: @employee.id,
-      menu_id: current_company.flower_shop.menus.ids.first,
-      deliver_to: 0,
-      discarded_at: nil
-    ).save
-  end
 
   def set_employees
     @employees = Employee.where(company_id: current_company.id)

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -24,9 +24,13 @@ class EmployeesController < ApplicationController
       rescue ActiveRecord::RecordInvalid => e
         flash[:danger] = e.record.errors.full_messages.join(', ')
       end
-    else
+    elsif @employee.save
       # 社員のみの場合
-      @employee.save ? flash[:success] = '社員を登録しました' : flash[:danger] = '社員の登録に失敗しました'
+      flash[:success] = '社員を登録しました'
+
+      update_order_detail if @employee.birthday_is_next_month?
+    else
+      flash[:danger] = '社員の登録に失敗しました'
     end
 
     redirect_to employees_path
@@ -53,6 +57,16 @@ class EmployeesController < ApplicationController
   end
 
   private
+
+  def update_order_detail
+    OrderDetail.create(
+      order_id: current_company.order_ids.last,
+      employee_id: @employee.id,
+      menu_id: current_company.flower_shop.menus.ids.first,
+      deliver_to: 0,
+      discarded_at: nil
+    ).save
+  end
 
   def set_employees
     @employees = Employee.where(company_id: current_company.id)

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -69,7 +69,8 @@ class EmployeesController < ApplicationController
   def set_new_employee
     @employee = Employee.new(employee_params)
     @employee.company_id = current_company.id
-    @employee.phone_number = ActiveRecord::Type::Boolean.new.cast(employee_params[:phone_number])
+    @employee.address = employee_params[:address].present? ? employee_params[:address] : nil
+    @employee.phone_number = employee_params[:phone_number].present? ? employee_params[:phone_number] : nil
   end
 
   def add_flash_danger_if_invalid

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -62,4 +62,11 @@ class Employee < ApplicationRecord
 
     diff_years
   end
+
+  def birthday_is_next_month?
+    next_month = Time.zone.now.next_month.strftime('%m').to_i
+    return true if birthday.month == next_month
+
+    false
+  end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -29,6 +29,20 @@ class Employee < ApplicationRecord
     end
   end
 
+  def save_with_order_detail(current_company)
+    transaction do
+      save!
+      order_detail = OrderDetail.new(
+        order_id: current_company.next_order.id,
+        employee_id: id,
+        menu_id: current_company.flower_shop.cheapest_menu.id,
+        deliver_to: 0,
+        discarded_at: nil
+      )
+      order_detail.save!
+    end
+  end
+
   def destroy_with_manager
     transaction do
       manager.destroy!

--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -29,7 +29,7 @@
                 <td class='align-middle small'><%= detail.object.employee.address %></td>
                 <td class='align-middle small'><%= detail.object.employee.working_years %>年</td>
                 <td class='align-middle small'>
-                  <% if detail.object.employee.address %>
+                  <% if detail.object.employee.address.present? %>
                     <%= detail.select :deliver_to,
                         options_for_select(@deliver_to, selected: detail.object.deliver_to),
                         {},

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,10 +47,10 @@ COMPANY_COUNT.times do |n|
 end
 
 EMPLOYEE_COUNT.times do |_n|
-  s1 = Date.parse('2000/07/1')
-  s2 = Date.parse('2000/07/30')
+  s1 = Date.parse('2000/08/1')
+  s2 = Date.parse('2000/08/30')
   s = Random.rand(s1..s2)
-  address = Random.rand(1..2).even? ? Gimei.unique.address : nil
+  address = Random.rand(1..2).even? ? Gimei.unique.address : ''
 
   Employee.create!(
     name: Gimei.unique.name.kanji,


### PR DESCRIPTION
## チケットへのリンク

* #107 

## やったこと

* 翌月誕生日の社員を登録する際、翌月誕生日なら注文データに追加する

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 翌月誕生日の社員を登録時に、注文データに追加される

## できなくなること（ユーザ目線）

* なし

## 動作確認

* seedのemployeesの addressをnilじゃなくて、空文字にした。
* `rails db:migrate:reset`
* `rails db:seed`
* 注文データを確認後に、翌月誕生日の社員を追加する
* 再度注文データを確認し、追加されているか確認する

## その他

* もっといい書き方がありそうなので、レビューオネシャス！！
