### PR TITLE
issue/#109 fix : 各モデルに設定されていたtemporariesとの関連を削除

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -48,7 +48,7 @@ class EmployeesController < ApplicationController
   def destroy
     name = @employee.name
 
-    if @employee.manager ? @employee.destroy_with_manager : @employee.destroy
+    if @employee.discard
       flash[:success] = "#{name}さんを削除しました"
     else
       flash[:danger] = "#{name}さんの削除に失敗しました"

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -48,7 +48,7 @@ class EmployeesController < ApplicationController
   def destroy
     name = @employee.name
 
-    if @employee.discard
+    if @employee.manager ? @employee.destroy_with_manager : @employee.discard
       flash[:success] = "#{name}さんを削除しました"
     else
       flash[:danger] = "#{name}さんの削除に失敗しました"

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,7 +3,6 @@
 class Employee < ApplicationRecord
   include Discard::Model
   default_scope -> { kept }
-
   belongs_to :company
   has_one :manager
   has_many :order_details
@@ -42,6 +41,13 @@ class Employee < ApplicationRecord
         discarded_at: nil
       )
       order_detail.save!
+    end
+  end
+
+  def destroy_with_manager
+    transaction do
+      manager.destroy!
+      discard!
     end
   end
 

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,7 +3,6 @@
 class Employee < ApplicationRecord
   belongs_to :company
   has_one :manager
-  has_many :temporaries, dependent: :destroy
   has_many :order_details
 
   validates :name, :sex, :birthday, :joined_at, :company_id, presence: true

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Employee < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   belongs_to :company
   has_one :manager
   has_many :order_details
@@ -39,13 +42,6 @@ class Employee < ApplicationRecord
         discarded_at: nil
       )
       order_detail.save!
-    end
-  end
-
-  def destroy_with_manager
-    transaction do
-      manager.destroy!
-      destroy!
     end
   end
 

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -3,7 +3,6 @@
 class Manager < ApplicationRecord
   belongs_to :employee
   belongs_to :company
-  has_many :temporaries
 
   validates :email, presence: true
   validates :is_president, inclusion: [true, false]

--- a/db/migrate/20230729052624_add_discarded_at_to_employees.rb
+++ b/db/migrate/20230729052624_add_discarded_at_to_employees.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDiscardedAtToEmployees < ActiveRecord::Migration[7.0]
+  def change
+    change_table :employees do |t|
+      t.datetime :discarded_at
+      t.index :discarded_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_11_124220) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_29_052624) do
   create_table "companies", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -42,7 +42,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_124220) do
     t.datetime "updated_at", null: false
     t.date "joined_at"
     t.date "birthday", null: false
+    t.datetime "discarded_at"
     t.index ["company_id"], name: "index_employees_on_company_id"
+    t.index ["discarded_at"], name: "index_employees_on_discarded_at"
   end
 
   create_table "flower_shops", charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
## チケットへのリンク

* #109 

## やったこと

* 削除機能のバグを修正
* employeeモデルとmanagerモデルに設定された `has_many :temporaries, dependent: :destroy`が残っていたので、エラーが出てました。ってことで該当箇所を削除

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
