### PR TITLE
feat : 社長と管理者を持つ、社員をわかりやすく表示した

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -104,15 +104,15 @@ class EmployeesController < ApplicationController
 
   def search_condition
     @employees = @employees
-                 .where(name_condition)
-                 .where(sex_condition)
-                 .where(birthday_condition)
-                 .where(address_condition)
-                 .where(joined_at_condition)
-                 .where(phone_number_condition)
-                 .where(message_condition)
-                 .where(company_condition)
-                 .distinct
+                  .where(name_condition)
+                  .where(sex_condition)
+                  .where(birthday_condition)
+                  .where(address_condition)
+                  .where(joined_at_condition)
+                  .where(phone_number_condition)
+                  .where(message_condition)
+                  .where(company_condition)
+                  .order_manager_is_president_desc
   end
 
   def name_condition

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -127,7 +127,6 @@ class EmployeesController < ApplicationController
     { sex: params[:sex] }
   end
 
-  # TODO: 日付単体で検索するユースケースはないと思うので、範囲検索にした方が良いかも(front側では月のみをintで渡す)
   def birthday_condition
     return nil if params[:birthday].blank?
 
@@ -140,7 +139,6 @@ class EmployeesController < ApplicationController
     Employee.arel_table[:address].matches("%#{params[:address]}%")
   end
 
-  # TODO: 日付単体で検索するユースケースはないと思う。こちらもユースケースに応じた検索方法に変更した方が良いかも(現時点では日付で検索)
   def joined_at_condition
     return nil if params[:joined_at].blank?
 

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -18,6 +18,10 @@ class Employee < ApplicationRecord
     where(birthday_in_next_month_condition).order(birthday: :asc)
   }
 
+  scope :order_manager_is_president_desc, lambda {
+    left_joins(:manager).order('managers.is_president DESC')
+  }
+
   def require_phune_number_if_address_exist
     errors.add(:phone_number, 'を入力してください') if address.present? && phone_number.blank?
   end

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -12,7 +12,10 @@
       <p class="h2">メンバー 一覧</p>
     </div>
     <div class="col-1">
-      <p class="align-text-bottom">現在 <%= @employees.count %>名</p>
+      <p class="align-text-bottom">現在 <%= @employees.size %>名</p>
+    </div>
+    <div class="col-2">
+      <p class="align-text-bottom">※ ☆は社長, ○は管理者です</p>
     </div>
   </div>
   <table class="table table-striped table-hover">
@@ -31,7 +34,15 @@
     <tbody>
       <% @employees.each do |employee| %>
         <tr>
-          <td class='align-middle small'><%= employee.name %></td>
+          <td class='align-middle small'>
+            <% if employee.manager.present? && employee.manager.is_president %>
+              <%= "☆#{employee.name}" %>
+            <% elsif employee.manager.present? %>
+              <%= "○#{employee.name}" %>
+            <% else %>
+              <%= employee.name %>
+            <% end %>
+          </td>
           <td class='align-middle small'><%= employee.sex %></td>
           <td class='align-middle small'><%= employee.birthday_format_yyyy_mm_dd %></td>
           <td class='align-middle small'><%= employee.age %>歳</td>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -14,7 +14,7 @@
     <div class="col-1">
       <p class="align-text-bottom">現在 <%= @employees.size %>名</p>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <p class="align-text-bottom">※ ☆は社長, ○は管理者です</p>
     </div>
   </div>


### PR DESCRIPTION
## チケットへのリンク

* #125 
## やったこと

* 社員の一覧表示の際に、社長には☆をつけ、管理者には、○をつけた

## やらないこと

* 社長と管理者が先頭に来るようにソートすること

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 一覧を表示してみて、社長と管理者にそれぞれ印が付けられているか。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
