### PR TITLE
feat : 注文データに入ってる社員を削除した場合、注文データからも削除する、またnilの社員を表示しないようにする

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -49,6 +49,11 @@ class EmployeesController < ApplicationController
     name = @employee.name
 
     if @employee.manager ? @employee.destroy_with_manager : @employee.discard
+      next_order = current_company.next_order
+      if next_order.order_details.exists?(employee_id: @employee.id)
+        next_order.order_details.where(employee_id: @employee.id).destroy_all
+      end
+
       flash[:success] = "#{name}さんを削除しました"
     else
       flash[:danger] = "#{name}さんの削除に失敗しました"
@@ -104,15 +109,15 @@ class EmployeesController < ApplicationController
 
   def search_condition
     @employees = @employees
-                  .where(name_condition)
-                  .where(sex_condition)
-                  .where(birthday_condition)
-                  .where(address_condition)
-                  .where(joined_at_condition)
-                  .where(phone_number_condition)
-                  .where(message_condition)
-                  .where(company_condition)
-                  .order_manager_is_president_desc
+                 .where(name_condition)
+                 .where(sex_condition)
+                 .where(birthday_condition)
+                 .where(address_condition)
+                 .where(joined_at_condition)
+                 .where(phone_number_condition)
+                 .where(message_condition)
+                 .where(company_condition)
+                 .order_manager_is_president_desc
   end
 
   def name_condition

--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -21,39 +21,41 @@
         <tbody>
           <% @next_order_details.each_with_index do |details| %>
             <%= fields_for 'details[]', details do |detail| %>
-              <tr>
-                <td class='align-middle small'><%= detail.object.employee.name %></td>
-                <td class='align-middle small'><%= detail.object.employee.sex %></td>
-                <td class='align-middle small'><%= detail.object.employee.birthday_format_mm_dd %></td>
-                <td class='align-middle small'><%= detail.object.employee.age %>歳</td>
-                <td class='align-middle small'><%= detail.object.employee.address %></td>
-                <td class='align-middle small'><%= detail.object.employee.working_years %>年</td>
-                <td class='align-middle small'>
-                  <% if detail.object.employee.address.present? %>
-                    <%= detail.select :deliver_to,
-                        options_for_select(@deliver_to, selected: detail.object.deliver_to),
+              <% if detail.object.employee.present? %>
+                <tr>
+                  <td class='align-middle small'><%= detail.object.employee.name %></td>
+                  <td class='align-middle small'><%= detail.object.employee.sex %></td>
+                  <td class='align-middle small'><%= detail.object.employee.birthday_format_mm_dd %></td>
+                  <td class='align-middle small'><%= detail.object.employee.age %>歳</td>
+                  <td class='align-middle small'><%= detail.object.employee.address %></td>
+                  <td class='align-middle small'><%= detail.object.employee.working_years %>年</td>
+                  <td class='align-middle small'>
+                    <% if detail.object.employee.address.present? %>
+                      <%= detail.select :deliver_to,
+                          options_for_select(@deliver_to, selected: detail.object.deliver_to),
+                          {},
+                          {class: "form-select w-100"}
+                      %>
+                    <% else %>
+                      <%= detail.select :deliver_to,
+                          options_for_select(@deliver_to, selected: @deliver_to['会社'], disabled: @deliver_to['自宅']),
+                          {},
+                          {class: "form-select w-100"}
+                      %>
+                    <% end %>
+                  </td>
+                  <td class='align-middle small'>
+                    <%= detail.select :menu_id,
+                        options_from_collection_for_select(@menus, "id", "name_with_price", detail.object.menu_id),
                         {},
                         {class: "form-select w-100"}
                     %>
-                  <% else %>
-                    <%= detail.select :deliver_to,
-                        options_for_select(@deliver_to, selected: @deliver_to['会社'], disabled: @deliver_to['自宅']),
-                        {},
-                        {class: "form-select w-100"}
-                    %>
-                  <% end %>
-                </td>
-                <td class='align-middle small'>
-                  <%= detail.select :menu_id,
-                      options_from_collection_for_select(@menus, "id", "name_with_price", detail.object.menu_id),
-                      {},
-                      {class: "form-select w-100"}
-                  %>
-                </td>
-                <td class='align-middle small'>
-                  <%= detail.check_box :discard ,{checked: detail.object.discarded?, class: "form-check w-75 text-center"}, true, false %>
-                </td>
-              </tr>
+                  </td>
+                  <td class='align-middle small'>
+                    <%= detail.check_box :discard ,{checked: detail.object.discarded?, class: "form-check w-75 text-center"}, true, false %>
+                  </td>
+                </tr>
+              <% end %>
             <% end %>
           <% end %>
         </tbody>


### PR DESCRIPTION
## チケットへのリンク

* #131 

## 背景
* 注文データに載ってる社員を削除したあとに注文データに移動するとサーバーエラーが発生していた。社員がnilであることが原因

## やったこと
* 社員削除のタイミングで、注文データに削除された社員がいたら、注文データからそのレコードを削除する

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 社員削除した時に、注文データからも削除されている

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 9月誕生日の社員を作成して、次回の注文に行き、追加されているか確認する
* その後、社員一覧でその社員を削除する、次回の注文に行き、削除した社員が消えているか確認
* next_order.order_detailsには削除された社員は含まれないようになったが、念の為、viewの方でnilチェック行っています。
* 確認オネシャス！

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
