### PR TITLE
fix : UIに関するテキストやレイアウトを修正

### DIFF
--- a/app/views/employees/_edit_modal.html.erb
+++ b/app/views/employees/_edit_modal.html.erb
@@ -32,7 +32,7 @@
             <%= form.text_area :message, class: "form-control", id: "message", placeholder: '' %>
           </div>
           <div class="col-12 my-2 text-center">
-            <%= form.submit "送信", class: "btn btn-primary px-5" %>
+            <%= form.submit "登録", class: "btn btn-primary px-5" %>
           </div>
         </div>
       <% end %>

--- a/app/views/employees/_new.html.erb
+++ b/app/views/employees/_new.html.erb
@@ -39,7 +39,7 @@
       <%= form.email_field :admin_mail_address, class: "form-control", id: "admin_mail_address" %>
     </div>
     <div class="col-12 mt-4 mb-2 text-center">
-      <%= form.submit "送信", class: "btn btn-primary px-5" %>
+      <%= form.submit "登録", class: "btn btn-primary px-5" %>
     </div>
   </div>
 <% end %>

--- a/app/views/employees/_search_form.html.erb
+++ b/app/views/employees/_search_form.html.erb
@@ -38,7 +38,7 @@
           <%= form.text_field :phone_number, class: "form-control" , id: "phone_number" %>
       </div>
       <div class="col-12 my-2 text-center">
-        <%= form.submit "送信" , class: "btn btn-primary px-5", id: "search-employee-btn" %>
+        <%= form.submit "絞り込む" , class: "btn btn-primary px-5", id: "search-employee-btn" %>
       </div>
     </div>
     <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,8 +1,13 @@
 <div class="navbar navbar-expand-lg navbar-light sticky-top bg-light">
   <nav class="rounded-pill bg-white shadow container-fluid mx-2 mb-1 py-3">
-    <p class="px-5 h3 m-0">One Step Gift</p>
+    <div class="row">
+      <div class="col">
+        <p class="h3 m-0 text-center px-5">One Step Gift</p>
+        <p class="h6 m-0 text-center px-5 pt-1">ようこそ <%= current_company.name %> 様</p>
+      </div>
+    </div>
     <div class='navbar-nav row d-flex w-50 my-1 mx-3' id="navbarNav">
-      <%= link_to current_company.name , root_path, class: "col nav-link text-center border-start py-0" %>
+      <%= link_to "ダッシュボード" , root_path, class: "col nav-link text-center border-start py-0" %>
       <%= link_to "お花一覧", "/お花一覧.pdf", target: :_blank, class: "col nav-link text-center border-start py-0" %>
       <%= link_to "次回の注文" , next_order_path, class: "col nav-link text-center border-start py-0" %>
       <%= link_to "ログアウト" , companies_sign_out_path, class: "col nav-link text-center border-start py-0" %>


### PR DESCRIPTION
## チケットへのリンク

* close #141 
* close #144 

## やったこと

* ヘッダーのレイアウト、テキストを変更
* ボタンのテキストを変更

<img width="1512" alt="スクリーンショット 2023-09-13 13 21 29" src="https://github.com/NODASHUSEINANODA/ohana_api/assets/69576936/b956061c-c251-4f99-a981-49413bace20c">
<img width="1512" alt="スクリーンショット 2023-09-13 13 21 38" src="https://github.com/NODASHUSEINANODA/ohana_api/assets/69576936/f4bd0e05-5969-4e0a-850f-6d9a39b8a67c">

## やらないこと

* サービス名の変更は別のプルリクでやる

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 画面上で確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
