### PR TITLE
Issue/#143 社員の誕生日を編集した場合に「次回の注文」のところに反映されないので修正

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -24,7 +24,7 @@ class EmployeesController < ApplicationController
       rescue ActiveRecord::RecordInvalid => e
         flash[:danger] = e.record.errors.full_messages.join(', ')
       end
-    elsif @employee.birthday_is_next_month?
+    elsif @employee.is_birthday_within_next_order_term?
       @employee.save_with_order_detail(current_company)
       flash[:success] = '社員を登録しました'
     elsif @employee.save!

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -37,7 +37,7 @@ class EmployeesController < ApplicationController
   end
 
   def update
-    if @employee.update(employee_params)
+    if @employee.update_with_order_detail(employee_params, current_company)
       flash[:success] = '社員情報を更新しました'
     else
       flash[:danger] = '社員情報の更新に失敗しました'

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -51,7 +51,7 @@ class Employee < ApplicationRecord
   def update_with_order_detail(employee_params, current_company)
     transaction do
       update!(employee_params)
-      if birthday_is_next_month?
+      if birthday_is_next_month? && OrderDetail.find_by(order_id: current_company.next_order.id, employee_id: id).nil?
         order_detail = OrderDetail.new(
           order_id: current_company.next_order.id,
           employee_id: id,
@@ -60,8 +60,10 @@ class Employee < ApplicationRecord
           discarded_at: nil
         )
         order_detail.save!
-      elsif OrderDetail.find_by(order_id: current_company.next_order.id, employee_id: id).present?
-        OrderDetail.find_by(order_id: current_company.next_order.id, employee_id: id).destroy!
+      elsif !birthday_is_next_month? && OrderDetail.find_by(order_id: current_company.next_order.id,
+                                                            employee_id: id).present?
+        order_detail = OrderDetail.find_by(order_id: current_company.next_order.id, employee_id: id)
+        order_detail.destroy!
       else
         true
       end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -48,6 +48,26 @@ class Employee < ApplicationRecord
     end
   end
 
+  def update_with_order_detail(employee_params, current_company)
+    transaction do
+      update!(employee_params)
+      if birthday_is_next_month?
+        order_detail = OrderDetail.new(
+          order_id: current_company.next_order.id,
+          employee_id: id,
+          menu_id: current_company.flower_shop.cheapest_menu_of_the_season.id,
+          deliver_to: 0,
+          discarded_at: nil
+        )
+        order_detail.save!
+      elsif OrderDetail.find_by(order_id: current_company.next_order.id, employee_id: id).present?
+        OrderDetail.find_by(order_id: current_company.next_order.id, employee_id: id).destroy!
+      else
+        true
+      end
+    end
+  end
+
   def destroy_with_manager
     transaction do
       manager.destroy!

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -18,6 +18,11 @@ class Order < ApplicationRecord
         end
       end
     end
+
+    # NOTE 今の仕様では全ての会社で同じ日付で注文するので、クラスメソッドとして定義
+    def order_date
+      return 15
+    end
   end
 
   def calc_amount

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ module App
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Only loads a smaller set of middleware suitable for API only apps.


### PR DESCRIPTION
## チケットへのリンク

* #143 

## やったこと

* 社員の誕生日を編集時に、次回の注文データも更新する

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 社員の編集時に次回の注文データが更新される

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 社員の誕生日の編集を以下のパターンで正しく実行されること
1. 社員の誕生日を(翌月以外から翌月に変更) → 注文データに登録される
2. 社員の誕生日を(翌月から翌月以外に変更)→注文データから消える
3. 社員の誕生日を(翌月から翌月に日にちだけ変更) → 注文データはそのまま
4. 社員の誕生日を(よく月以外から翌月以外に変更)→ 注文データは変わらない

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
