### PR TITLE
Issue/#134 注文詳細にメッセージを追加

### DIFF
--- a/app/controllers/order_details_controller.rb
+++ b/app/controllers/order_details_controller.rb
@@ -17,7 +17,8 @@ class OrderDetailsController < ApplicationController
       detail.update(
         deliver_to: param[:deliver_to],
         menu_id: param[:menu_id].to_i,
-        discarded_at: param[:discard].present? ? Time.zone.now : nil
+        discarded_at: param[:discard].present? ? Time.zone.now : nil,
+        birthday_message: param[:birthday_message]
       )
     end
 

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -42,7 +42,8 @@ class Employee < ApplicationRecord
         employee_id: id,
         menu_id: current_company.flower_shop.cheapest_menu_of_the_season.id,
         deliver_to: 0,
-        discarded_at: nil
+        discarded_at: nil,
+        birthday_message: "#{name}さん、お誕生日おめでとうございます！"
       )
       order_detail.save!
     end
@@ -61,7 +62,8 @@ class Employee < ApplicationRecord
           employee_id: id,
           menu_id: current_company.flower_shop.cheapest_menu_of_the_season.id,
           deliver_to: 0,
-          discarded_at: nil
+          discarded_at: nil,
+          birthday_message: "#{name}さん、お誕生日おめでとうございます！"
         )
         order_detail.save!
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -28,6 +28,7 @@ class OrderDetail < ApplicationRecord
   def prepare_for_company_mailer
     {
       employee_name: employee.name,
+      employee_age: employee.age_after_birthday,
       employee_birthday: employee.birthday_format_mm_dd,
       delivery_address: delivery_address,
       menu_name_with_price: menu.name_with_price,

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -30,7 +30,8 @@ class OrderDetail < ApplicationRecord
       employee_name: employee.name,
       employee_birthday: employee.birthday_format_mm_dd,
       delivery_address: delivery_address,
-      menu_name_with_price: menu.name_with_price
+      menu_name_with_price: menu.name_with_price,
+      birthday_message: birthday_message
     }
   end
 

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -13,12 +13,14 @@ class OrderDetail < ApplicationRecord
 
   class << self
     def setup_next_order_detail(order_id, employee_id, menu_id)
+      employee_name = Employee.find(employee_id).name
       OrderDetail.create(
         order_id: order_id,
         employee_id: employee_id,
         menu_id: menu_id,
         deliver_to: 0,
-        discarded_at: nil
+        discarded_at: nil,
+        birthday_message: "#{employee_name}さん、お誕生日おめでとうございます！"
       )
     end
   end

--- a/app/views/company_mailer/order_to_flower_shop.html.erb
+++ b/app/views/company_mailer/order_to_flower_shop.html.erb
@@ -13,6 +13,7 @@
       <thead>
         <tr>
           <th>名前</th>
+          <th>誕生日メッセージ</th>
           <th>到着日付</th>
           <th>宛先</th>
           <th>メニュー</th>
@@ -22,6 +23,7 @@
         <% @next_orders_info.each do |info| %>
           <tr>
               <td class='align-middle small'><%= info[:employee_name] %></td>
+              <td class='align-middle small'><%= info[:birthday_message] %></td>
               <td class='align-middle small'><%= info[:employee_birthday] %></td>
               <td class='align-middle small'><%= info[:delivery_address] %></td>
               <td class='align-middle small'><%= info[:menu_name_with_price] %></td>

--- a/app/views/company_mailer/order_to_flower_shop.html.erb
+++ b/app/views/company_mailer/order_to_flower_shop.html.erb
@@ -13,6 +13,7 @@
       <thead>
         <tr>
           <th>名前</th>
+          <th>年齢</th>
           <th>誕生日メッセージ</th>
           <th>到着日付</th>
           <th>宛先</th>
@@ -23,6 +24,7 @@
         <% @next_orders_info.each do |info| %>
           <tr>
               <td class='align-middle small'><%= info[:employee_name] %></td>
+              <td class='align-middle small'><%= info[:employee_age] %></td>
               <td class='align-middle small'><%= info[:birthday_message] %></td>
               <td class='align-middle small'><%= info[:employee_birthday] %></td>
               <td class='align-middle small'><%= info[:delivery_address] %></td>

--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -39,7 +39,9 @@
                   <% end %>
                   <td class='align-middle small'><%= detail.object.employee.age_after_birthday %>歳</td>
                   <td class='align-middle small'>
-                    <%= detail.text_area :birthday_message %>
+                    <textarea class='w-100'>
+                      <%= detail.object.birthday_message %>
+                    </textarea>
                   </td>
                   <td class='align-middle small'>
                     <% if detail.object.employee.address.present? %>

--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -39,9 +39,7 @@
                   <% end %>
                   <td class='align-middle small'><%= detail.object.employee.age_after_birthday %>歳</td>
                   <td class='align-middle small'>
-                    <textarea class='w-100'>
-                      <%= detail.object.birthday_message %>
-                    </textarea>
+                    <%= detail.text_area :birthday_message, class: 'w-100' %>
                   </td>
                   <td class='align-middle small'>
                     <% if detail.object.employee.address.present? %>

--- a/app/views/order_details/edit.html.erb
+++ b/app/views/order_details/edit.html.erb
@@ -16,11 +16,8 @@
         <thead class='bg-white'>
           <tr>
             <th>名前</th>
-            <th>性別</th>
-            <th>誕生日</th>
-            <th>年齢</th>
-            <th>住所</th>
-            <th>勤続年数</th>
+            <th>年齢(誕生日当日)</th>
+            <th>メッセージ</th>
             <th>送り先</th>
             <th>メニュー</th>
             <th>今回は送らない</th>
@@ -40,11 +37,10 @@
                       <%= "#{detail.object.employee.name}" %>
                     </td>
                   <% end %>
-                  <td class='align-middle small'><%= detail.object.employee.sex %></td>
-                  <td class='align-middle small'><%= detail.object.employee.birthday_format_mm_dd %></td>
                   <td class='align-middle small'><%= detail.object.employee.age_after_birthday %>歳</td>
-                  <td class='align-middle small'><%= detail.object.employee.address %></td>
-                  <td class='align-middle small'><%= detail.object.employee.working_years %>年</td>
+                  <td class='align-middle small'>
+                    <%= detail.text_area :birthday_message %>
+                  </td>
                   <td class='align-middle small'>
                     <% if detail.object.employee.address.present? %>
                       <%= detail.select :deliver_to,

--- a/app/views/order_mailer/shipping_confirmation_to_president.html.erb
+++ b/app/views/order_mailer/shipping_confirmation_to_president.html.erb
@@ -15,6 +15,7 @@
       <thead>
         <tr>
           <th>名前</th>
+          <th>誕生日メッセージ</th>
           <th>到着日付</th>
           <th>宛先</th>
           <th>メニュー</th>
@@ -24,6 +25,7 @@
         <% @next_orders_info.each do |info| %>
           <tr>
               <td class='align-middle small'><%= info[:employee_name] %></td>
+              <td class='align-middle small'><%= info[:birthday_message] %></td>
               <td class='align-middle small'><%= info[:employee_birthday] %></td>
               <td class='align-middle small'><%= info[:delivery_address] %></td>
               <td class='align-middle small'><%= info[:menu_name_with_price] %></td>

--- a/app/views/order_mailer/shipping_confirmation_to_president.html.erb
+++ b/app/views/order_mailer/shipping_confirmation_to_president.html.erb
@@ -15,6 +15,7 @@
       <thead>
         <tr>
           <th>名前</th>
+          <th>年齢</th>
           <th>誕生日メッセージ</th>
           <th>到着日付</th>
           <th>宛先</th>
@@ -25,6 +26,7 @@
         <% @next_orders_info.each do |info| %>
           <tr>
               <td class='align-middle small'><%= info[:employee_name] %></td>
+              <td class='align-middle small'><%= info[:employee_age] %></td>
               <td class='align-middle small'><%= info[:birthday_message] %></td>
               <td class='align-middle small'><%= info[:employee_birthday] %></td>
               <td class='align-middle small'><%= info[:delivery_address] %></td>

--- a/db/migrate/20230915142936_add_birthday_message_to_order_details.rb
+++ b/db/migrate/20230915142936_add_birthday_message_to_order_details.rb
@@ -1,0 +1,7 @@
+class AddBirthdayMessageToOrderDetails < ActiveRecord::Migration[7.0]
+  def change
+    change_table :order_details do |t|
+      t.text :birthday_message
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_31_113525) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_15_142936) do
   create_table "companies", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_113525) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
+    t.text "birthday_message"
     t.index ["discarded_at"], name: "index_order_details_on_discarded_at"
     t.index ["employee_id"], name: "index_order_details_on_employee_id"
     t.index ["menu_id"], name: "index_order_details_on_menu_id"

--- a/lib/tasks/order.rb
+++ b/lib/tasks/order.rb
@@ -4,7 +4,7 @@ class Tasks::Order < Tasks::AbstBatch
   def self.exec
     execute('注文を開始します') do
       Company.all.each do |company|
-        # NOTE できればeach内の処理を`app/use_cases/company/send_mail_to_flower_shop.rb`を作成し、そこで行いたい
+        # NOTE: できればeach内の処理を`app/use_cases/company/send_mail_to_flower_shop.rb`を作成し、そこで行いたい
         formatted_next_orders = company.next_order_details.map(&:prepare_for_company_mailer)
 
         if formatted_next_orders.present?


### PR DESCRIPTION
## チケットへのリンク

* close #134 

## やったこと

* 次回の注文確認にメッセージの項目を追加
* 初期値は、注文データ作成時、該当の誕生日の社員が登録されたとき、変更で該当の誕生日に更新されたときも
* メール文面に誕生日メッセージとして、メッシー字をを入れた

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 次回の注文確認で、メッセージを編集できるか確認お願いしまう。
* 最初モーダルでやるって話だったけど、普通のテキストエリアでもそこまでおかしくなかった(本音を言うとメッセージだけモーダル表示で編集が上手くいかんかった。)
* メールの確認もして欲しいです。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
