### PR TITLE
Issue/#142 サインアップの際に会社名を入力すると10文字以上は入力できないようになっているため、100文字まで入力できるようにする

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -6,7 +6,7 @@ class Company < ApplicationRecord
   has_many :orders, dependent: :destroy
   belongs_to :flower_shop
 
-  validates :name, presence: true, length: { maximum: 20, allow_blank: true }
+  validates :name, presence: true, length: { maximum: 100, allow_blank: true }
   validates :address, presence: true, length: { maximum: 40, allow_blank: true }
 
   # この:validatableはpasswordとemailしか検証してくれない

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -7,7 +7,7 @@ class Company < ApplicationRecord
   belongs_to :flower_shop
 
   validates :name, presence: true, length: { maximum: 100, allow_blank: true }
-  validates :address, presence: true, length: { maximum: 40, allow_blank: true }
+  validates :address, presence: true, length: { maximum: 100, allow_blank: true }
 
   # この:validatableはpasswordとemailしか検証してくれない
   devise :database_authenticatable, :registerable,


### PR DESCRIPTION
## チケットへのリンク

* close #142 

## やったこと

* 会社名を100文字まで許容
* 会社の住所を100文字まで許容

## 動作確認

* ローカル環境で20文字以上の値を持つ会社名で登録できるか検証した

## その他

* 会社名で幅を持たせるように指示があったので、住所も言われそうだなと思い、同じ100文字にしました。
