### PR TITLE
issue/#163 注文メールに管理者のアドレスをCcとして追加

### DIFF
--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -13,6 +13,7 @@ class OrderMailer < ApplicationMailer
 
     mail(
       to: @president_email,
+      cc: @manager_emails,
       subject: SUBJECT
     )
   end
@@ -20,6 +21,7 @@ class OrderMailer < ApplicationMailer
   def no_shipping_confirmation_to_president
     mail(
       to: @president_email,
+      cc: @manager_emails,
       subject: SUBJECT
     )
   end
@@ -39,5 +41,6 @@ class OrderMailer < ApplicationMailer
   def set_president_name_and_email
     @president_name = params[:president_name]
     @president_email = params[:president_email]
+    @manager_emails = params[:manager_emails]
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -37,22 +37,35 @@ class Order < ApplicationRecord
 
   # formatted_next_ordersは、OrderDetailのprepare_for_company_mailerメソッドの返り値を指定
   def shipping_confirmation_to_president(formatted_next_orders)
-    president = company.president
+    president = my_president
+    manager_emails = my_managers.pluck(:email)
 
     OrderMailer.with(
       president_name: president.employee.name,
       president_email: president.email,
+      manager_emails: manager_emails,
       next_orders_info: formatted_next_orders,
       total_amount: calc_amount
     ).shipping_confirmation_to_president.deliver_now
   end
 
   def no_shipping_confirmation_to_president
-    president = company.president
+    president = my_president
+    manager_emails = my_managers.pluck(:email)
 
     OrderMailer.with(
       president_name: president.employee.name,
-      president_email: president.email
+      president_email: president.email,
+      manager_emails: manager_emails,
     ).no_shipping_confirmation_to_president.deliver_now
+  end
+
+  private
+  def my_president
+    company.president
+  end
+
+  def my_managers
+    my_president.employee.company.managers.not_presidents
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -66,6 +66,6 @@ class Order < ApplicationRecord
   end
 
   def my_managers
-    my_president.employee.company.managers.not_presidents
+    company.managers.not_presidents
   end
 end


### PR DESCRIPTION
## チケットへのリンク

* close #163 

## やったこと

* 注文メールに管理者のアドレスをCcとして追加

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* ローカルで `rails runner Tasks::Order.exec` を叩いて、結果を確認

## その他

* オネシャス！！！！！！
