### PR TITLE
#176 feat : 入社日を必須項目から外す、必須項目をわかりやすくする

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -7,7 +7,7 @@ class Employee < ApplicationRecord
   has_one :manager, dependent: :destroy
   has_many :order_details, dependent: :destroy
 
-  validates :name, :sex, :birthday, :joined_at, :company_id, presence: true
+  validates :name, :sex, :birthday, :company_id, presence: true
   validates :phone_number, format: { with: /\A\d{10,11}\z/ }, allow_nil: true, allow_blank: true # 電話番号は10桁or11桁の数字のみ
   validate :require_phune_number_if_address_exist
 
@@ -133,6 +133,8 @@ class Employee < ApplicationRecord
   private
 
   def calc_how_many_years_passed(input_date)
+    return 0 if input_date.nil?
+
     now = Time.now.utc.to_date
     now.year - input_date.year - (input_date.change(year: now.year) > now ? 1 : 0)
   end

--- a/app/views/employees/_new.html.erb
+++ b/app/views/employees/_new.html.erb
@@ -3,7 +3,7 @@
 <%= form_with(model: Employee.new, remote: true) do |form| %>
   <div class="row mt-2 mb-4 py-3 container rounded shadow bg-white">
     <div class="col-2">
-      <%= form.label '名前', class: "form-label" %>
+      <%= form.label '名前', class: "form-label" %><span class="text-danger">(必須)</span>
       <%= form.text_field :name, class: "form-control", id: "name" %>
     </div>
     <div class="col-2">
@@ -11,7 +11,7 @@
       <%= form.select :sex, [["--選択--", "invalid"], ["男性", "男性"], ["女性", "女性"], ["無回答", "無回答"]], {}, class: "form-select", aria: {label: "sex"}, id: "sex" %>
     </div>
     <div class="col-2">
-      <%= form.label 'お誕生日', class: "form-label" %>
+      <%= form.label 'お誕生日', class: "form-label" %><span class="text-danger">(必須)</span>
       <%= form.date_field :birthday, class: "form-control", id: "birthday" %>
     </div>
     <div class="col-2">


### PR DESCRIPTION
## チケットへのリンク

* #176

## やったこと

* 入社日を必須項目から外す、必須項目をわかりやすくする

## できるようになること（ユーザ目線）

* 必須項目がわかる

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 名前と誕生日にだけ、必須のバリデーションがかかるか、正常に登録処理ができるか
* 入社日を入力しなかった場合、勤続年数は0年と表示されるか

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
