### PR TITLE
issue/#182 feat : 翌々月の誕生を次回の注文にセットする

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -81,7 +81,7 @@ class Company < ApplicationRecord
   end
 
   def employees_with_birthdays_next_month
-    employees.birthdays_in_next_month
+    employees.birthday_within_two_months_later
   end
 
   private

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -45,7 +45,7 @@ class Company < ApplicationRecord
   end
 
   def setup_next_order
-    birthday_employee_ids = employees_with_birthdays_next_month.pluck(:id)
+    birthday_employee_ids = employees.birthday_within_two_months_later.pluck(:id)
     default_menu_id = flower_shop.cheapest_menu_of_the_season.id
 
     Order.setup_next_order(id, flower_shop.id, birthday_employee_ids, default_menu_id)
@@ -78,10 +78,6 @@ class Company < ApplicationRecord
       flower_shop_name: flower_shop.name,
       flower_shop_email: flower_shop.email
     ).no_order_to_flower_shop.deliver_now
-  end
-
-  def employees_with_birthdays_next_month
-    employees.birthday_within_two_months_later
   end
 
   private

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -11,8 +11,8 @@ class Employee < ApplicationRecord
   validates :phone_number, format: { with: /\A\d{10,11}\z/ }, allow_nil: true, allow_blank: true # 電話番号は10桁or11桁の数字のみ
   validate :require_phune_number_if_address_exist
 
-  scope :birthdays_in_next_month, lambda {
-    next_month = Time.zone.now.next_month.strftime('%m')
+  scope :birthday_within_two_months_later, lambda {
+    next_month = Time.zone.now.since(2.month).strftime('%m')
     birthday_in_next_month_condition = Employee.arel_table[:birthday].extract('month').eq(next_month)
 
     where(birthday_in_next_month_condition).order(birthday: :asc)


### PR DESCRIPTION
## チケットへのリンク

* close #182 

## やったこと

* 翌々月の誕生を次回の注文にセットする

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 翌々月の誕生を次回の注文にセットされている

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
