### PR TITLE
#187 feat : 注文メールのメニューを注文データの月と合わせる

### DIFF
--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -10,12 +10,12 @@ class Menu < ApplicationRecord
 
   scope :cheapest, -> { order(price: :asc).first }
   scope :season_menu, lambda {
-    spring_term = [2, 3, 4]
-    summer_term = [5, 6, 7]
-    automn_term = [8, 9, 10]
-    winter_term = [11, 12, 1]
+    spring_term = [3, 4, 5]
+    summer_term = [6, 7, 8]
+    automn_term = [9, 10, 11]
+    winter_term = [12, 1, 2]
 
-    case Time.now.month
+    case Time.zone.now.since(2.month).strftime('%m').to_i
     when *spring_term
       where(season: %i[spring all_season])
     when *summer_term


### PR DESCRIPTION
## チケットへのリンク

* close #187 

## やったこと

* 注文データのメニューを注文データの月と合わせるようにした

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* 新しく注文メールを送信したときに、新規で作られる注文データのメニューが注文データの月とあっているか確認
* 補足
* taskが走る瞬間に注文データは2か月先のものを取得するので、同じように、menuも2ヶ月先のメニュープランにするように変更しています

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
